### PR TITLE
Add: New requirements for production

### DIFF
--- a/Mystic_Tuner_Backend/Database_Connector/database_connector.py
+++ b/Mystic_Tuner_Backend/Database_Connector/database_connector.py
@@ -1,5 +1,7 @@
 import psycopg2
 from psycopg2.extras import execute_values
+from django.db import connection
+from django.utils.connection import ConnectionProxy
 
 class DatabaseConnector():
     """
@@ -36,15 +38,18 @@ class DatabaseConnector():
         return:
             success of connection (boolean)
         """
-        #TODO implement environment variables to get connection details
         try:
-            self.connection = psycopg2.connect(
-                host = host,
-                dbname = database_name,
-                user = user,
-                password = password,
-                port = port
-            )
+            # TODO get this operational with django locally
+            self.connection: ConnectionProxy = connection
+            # Alternatively, call os.environ.get() to get the environment variables
+            # Must account for both development and production environments vars see settings.py
+            # self.connection = psycopg2.connect(
+            #     host = host,
+            #     dbname = database_name,
+            #     user = user,
+            #     password = password,
+            #     port = port
+            # )
             print("Connection successfully established with database")
 
         except Exception as e:

--- a/Mystic_Tuner_Backend/Mystic_Tuner_Backend/settings.py
+++ b/Mystic_Tuner_Backend/Mystic_Tuner_Backend/settings.py
@@ -88,17 +88,6 @@ TEMPLATES = [
 WSGI_APPLICATION = 'Mystic_Tuner_Backend.wsgi.application'
 
 
-# Database
-# https://docs.djangoproject.com/en/5.1/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
-}
-
-
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
Django uses the DATABASES variable to connect to a database. You can still use psycopg2 manually but the production environment variable is different from development, it uses DATABASE_URL as well. However, this may just be the DB_HOST, but heroku stores it as DATABASE_URL and that is not supposed to be changed.

EDIT: These are not the same and should be treated differently. Use DATABASE_URL
